### PR TITLE
Don't trim all trailing whitespaces but remove just a single CR at the EOL

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,10 @@ Parser.prototype.write = function(chunk){
 
 Parser.prototype.online = function(line){
   // Remove a single CR at the end of the line if it does exist
+  line = line.replace(/\r$/, '');
+
   debug('line %s', util.inspect(line));
-  var orig = line = line.replace(/\r$/, '');
+  var orig = line;
 
   // prefix
   if (':' == line[0]) {

--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ Parser.prototype.write = function(chunk){
  */
 
 Parser.prototype.online = function(line){
-  // trim
+  // Remove a single CR at the end of the line if it does exist
   debug('line `%s`', line);
-  var orig = line = line.trim();
+  var orig = line = line.replace(/\r$/, '');
 
   // prefix
   if (':' == line[0]) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+const util = require('util');
 var debug = require('debug')('slate-irc-parser');
 var linewise = require('linewise');
 var Stream = require('stream');
@@ -54,7 +55,7 @@ Parser.prototype.write = function(chunk){
 
 Parser.prototype.online = function(line){
   // Remove a single CR at the end of the line if it does exist
-  debug('line `%s`', line);
+  debug('line %s', util.inspect(line));
   var orig = line = line.replace(/\r$/, '');
 
   // prefix

--- a/test/index.js
+++ b/test/index.js
@@ -10,23 +10,23 @@ describe('Parser', function(){
     parser.on('message', function(msg){
       switch (n++) {
         case 0:
-          assert('hitchcock.freenode.net' == msg.prefix);
-          assert('NOTICE' == msg.command);
-          assert('*' == msg.params);
-          assert('*** Looking up your hostname...' == msg.trailing);
+          assert.equal('hitchcock.freenode.net', msg.prefix);
+          assert.equal('NOTICE', msg.command);
+          assert.equal('*', msg.params);
+          assert.equal('*** Looking up your hostname...', msg.trailing);
           assert(msg.string);
           break;
         case 1:
-          assert('' === msg.prefix);
-          assert('ERROR' == msg.command);
-          assert('' === msg.params);
-          assert('Closing Link: 127.0.0.1 (Connection timed out)' == msg.trailing);
+          assert.equal('', msg.prefix);
+          assert.equal('ERROR', msg.command);
+          assert.equal('', msg.params);
+          assert.equal('Closing Link: 127.0.0.1 (Connection timed out)', msg.trailing);
           break;
         case 2:
-          assert('tjholowaychuk!~tjholoway@S01067cb21b2fd643.gv.shawcable.net' == msg.prefix);
-          assert('JOIN' == msg.command);
-          assert('#express' == msg.params);
-          assert('' === msg.trailing);
+          assert.equal('tjholowaychuk!~tjholoway@S01067cb21b2fd643.gv.shawcable.net', msg.prefix);
+          assert.equal('JOIN', msg.command);
+          assert.equal('#express', msg.params);
+          assert.equal('', msg.trailing);
           done();
           break;
       }


### PR DESCRIPTION
#### 1. Don't trim trailing whitespaces but remove a single CR at the EOL

``` diff
@@ -53,9 +53,9 @@
  */

 Parser.prototype.online = function(line){
-  // trim
+  // Remove a single CR at the end of the line if it does exist
   debug('line `%s`', line);
-  var orig = line = line.trim();
+  var orig = line = line.replace(/\r$/, '');

   // prefix
   if (':' == line[0]) {
```

If you `.trim()` the whole line, it will result in removal of all trailing whitespaces which is not desirable.

Instead, we can remove only a single CR at the EOL using `.replace(/\r$/, '')`.

Current IRC spec documents specifies messages to be separated with CRLF not not LF, but most IRC servers accepts LF-separated messages so we need to support it too.

Since `linewise` package separates a stream into LF-separated lines, slate-irc-parser need to remove a CR at the end of the line.
###### Reference:
- https://tools.ietf.org/html/rfc1459#section-2.3.1
- https://tools.ietf.org/html/rfc2812#section-2.3.1
#### 2. Print `util.inspect(line)` instead of `line` to debug console

If you print `line` directly to the screen, whitespaces like '\r', '\n', '\b' or terminal control characters like '\x1b[33m' will ruin your screen. We need to print `util.inspect(line)` instead, so that lines will be properly escaped
#### 3. Do not print trailing '\r' into the debug console
#### 4. Use `assert.equal` instead of `assert` whenever possible
